### PR TITLE
Moved solid-multi-rp-client itself to @solid org scope

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "solid-multi-rp-client",
-  "version": "0.4.2",
+  "name": "@solid/solid-multi-rp-client",
+  "version": "0.4.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "solid-multi-rp-client",
-  "version": "0.4.2",
+  "name": "@solid/solid-multi-rp-client",
+  "version": "0.4.3",
   "description": "OpenID Connect client for multiple Relying Parties for Solid",
   "main": "./src/index.js",
   "scripts": {


### PR DESCRIPTION
After updating dependencies to point to @solid scope, moving solid-multi-rp-client itself into the @solid npm org.